### PR TITLE
Improve some entity physics

### DIFF
--- a/src/Scene/GameScene.cpp
+++ b/src/Scene/GameScene.cpp
@@ -20,7 +20,7 @@ GameScene::GameScene()
 
     getModel()->spawnPlayerMob(genericMobData, 0, 0);
     getModel()->spawnMob(genericMobData, 8, 0);
-    getModel()->spawnMob(genericMobData,-8, 0);
+    getModel()->spawnMob(heavyMobData,-8, 0);
 }
 GameScene::~GameScene() {}
 
@@ -100,7 +100,7 @@ void GameScene::loadWidgets() {
 			if (!pMob) return;
 
 			char msg[256];
-			sprintf(msg, "Position: (%.2f, %.2f)", pMob->x, pMob->y);
+			sprintf(msg, "Position: (%.3f, %.3f), Life: %.3f", pMob->x, pMob->y, pMob->life);
 			widget->renderText(uiManager, msg, textColor);
 		} );
 	widgetManager.loadWidget(newWidget);

--- a/src/Scene/GameSceneInput.cpp
+++ b/src/Scene/GameSceneInput.cpp
@@ -50,32 +50,34 @@ void GameScene::updateFromKeys(const KeyboardState &keyboardState) {
     {   Mob* playerMob = getModel()->getPlayerMob();
         if (playerMob) {
             float maxVel = .2f;
-            float force = .2f;
+            float maxForce = .2f;
             float forceX = 0,
                   forceY = 0;
 
             if ((keyboardState.isKeyDown(SDLK_LEFT) ||
                  keyboardState.isKeyDown(SDLK_a)) &&
                 playerMob->xvel > -maxVel)
-                forceX -= force;
+                forceX -= 1;
 
             if ((keyboardState.isKeyDown(SDLK_RIGHT) ||
                  keyboardState.isKeyDown(SDLK_d)) &&
                 playerMob->xvel < maxVel)
-                forceX += force;
+                forceX += 1;
 
             if ((keyboardState.isKeyDown(SDLK_UP) ||
                  keyboardState.isKeyDown(SDLK_w)) &&
                 playerMob->yvel < maxVel)
-                forceY += force;
+                forceY += 1;
 
             if ((keyboardState.isKeyDown(SDLK_DOWN) ||
                  keyboardState.isKeyDown(SDLK_s)) &&
                 playerMob->yvel > -maxVel)
-                forceY -= force;
+                forceY -= 1;
 
-            if (forceX != 0 || forceY != 0)
-                playerMob->applyForce(forceX, forceY);
+            if (forceX != 0 || forceY != 0) {
+                float forgeMag = getdist(forceX, forceY);
+                playerMob->applyForce((forceX/forgeMag) *maxForce, (forceY/forgeMag) *maxForce);
+            }
         }
     }
 }

--- a/src/Scene/Model/Mob.cpp
+++ b/src/Scene/Model/Mob.cpp
@@ -20,11 +20,11 @@ Mob::Mob(const MobData &data, float x, float y)
 void Mob::doTick() {
     Entity::doTick();
 
-    float maxVelChange2 = .01f;
-    float vel2 = getdist2(xvel, yvel);
-    if (vel2 <= maxVelChange2) xvel = yvel = 0;
+    float maxVelChange = .1f;
+    float vel = getdist(xvel, yvel);
+    if (vel <= maxVelChange) xvel = yvel = 0;
     else {
-        float mod = (vel2 - maxVelChange2) / vel2;
+        float mod = (vel - maxVelChange) / vel;
         xvel *= mod;
         yvel *= mod;
     }

--- a/src/Scene/Model/Mob.hpp
+++ b/src/Scene/Model/Mob.hpp
@@ -13,6 +13,7 @@ struct MobData : EntityData {
     MobData(const EntityData& entityData, float radius, float maxLife, float mass);
 };
 const MobData genericMobData(genericEntityData, 1, 1, 1);
+const MobData heavyMobData(genericEntityData, 2, 2, 8);
 
 
 


### PR DESCRIPTION
For #31
- Mob-mob collision resolution doesn't rely on penetration depth anymore
- Mob-projectile collision resolution resolves the projectile's position to the initial point of contact (not accurate for moving mobs but good enough)
- Reduced player's move speed, and player's diagonal move speed has been normalized